### PR TITLE
Add formality classifier evaluation script.

### DIFF
--- a/IWSLT2023/README.md
+++ b/IWSLT2023/README.md
@@ -44,18 +44,17 @@ formality level is one of: `formal` or `informal`.
 
 ### Additional Resources
 
-We [release](https://github.com/amazon-science/contrastive-controlled-mt/releases/tag/classifier-v1.0.0) a multilingual classifier trained to predict the formality of a text for the language pairs: EN-KO, EN-VI, EN-RU and EN-PT. We finetune [xlm-roberta-base](https://huggingface.co/xlm-roberta-base) model on human-written formal and informal text following the setup from [Briakou et al., EMNLP 2021](https://aclanthology.org/2021.emnlp-main.100.pdf). The model can be used as follows (after installing [transformers](https://pypi.org/project/transformers/)):
+We [release](https://github.com/amazon-science/contrastive-controlled-mt/releases/tag/classifier-v1.0.0) a multilingual classifier trained to predict the formality of a text for the language pairs: EN-KO, EN-VI, EN-RU and EN-PT. We finetune [xlm-roberta-base](https://huggingface.co/xlm-roberta-base) model on human-written formal and informal text following the setup from [Briakou et al., EMNLP 2021](https://aclanthology.org/2021.emnlp-main.100.pdf). The returned scores are probabilities corresponding to each label with `label0` and `label1` corresponding to the `informal` and `formal` classes respectively.
 
-```python
-from transformers import AutoTokenizer, AutoModelForSequenceClassification, TextClassificationPipeline
-import torch
-model_name = "xlm-roberta-base"
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-model = AutoModelForSequenceClassification.from_pretrained(<path to the downloaded model directory>)
-pipe = TextClassificationPipeline(model=model, tokenizer=tokenizer)
-scores = pipe(text, return_all_scores=True)
+Assuming the classifier has been extracted to `/tmp/`, the evaluation can be performed as follows (after installing [transformers](https://pypi.org/project/transformers/)):
+
+```bash
+python formality_classifier.py -m /tmp/xlmr-classifier -t formal -i /path/to/formality-control-1.formal.ko
 ```
-The returned scores are probabilities corresponding to each label with label0 and label1 corresponding to the informal and formal classes respectively.
+
+For a full list of options including device settings and batch size, see `python formality_classifier.py --help`.
+
+
 
 ## Citation
 

--- a/IWSLT2023/formality_classifier.py
+++ b/IWSLT2023/formality_classifier.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+from statistics import mean
+from argparse import ArgumentParser, FileType
+
+from transformers import AutoTokenizer, AutoModelForSequenceClassification, TextClassificationPipeline
+
+def setup_argparse():
+    parser = ArgumentParser()
+    parser.add_argument("-m", "--model-name", type=str, required=True, help="The path to the XLMR-based formality classifier.")
+    parser.add_argument("-t", "--target-formality", choices=("formal", "informal"), required=True, help="The formality level of the generated outputs.")
+    parser.add_argument("-i", "--input-stream", type=FileType("r"), default="-", help="The stream of system hypotheses.")
+    parser.add_argument("-bs", "--batch-size", type=int, default=32, help="The batch size for inference.")
+    parser.add_argument("-d", "--device", type=str, default="cpu", help="The device on which to run inference.")
+    return parser 
+
+if __name__ == "__main__":
+    args = setup_argparse().parse_args()
+
+    model_name = args.model_name
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    expected_label = "label0" if args.target_formality == "informal" else "label1"
+
+    model = AutoModelForSequenceClassification.from_pretrained(model_name)
+    
+    pipe = TextClassificationPipeline(model=model, tokenizer=tokenizer, batch_size=args.batch_size, device=args.device)
+    text = [line.strip() for line in args.input_stream]
+    scores = pipe(text)
+    print(mean((e["label"] == expected_label for e in scores)))


### PR DESCRIPTION
This adds the script to compute the predicted accuracy of a system output relative to a target formality using the formality classifier. Instructions are included for using the included script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
